### PR TITLE
Set registry url in order to auth properly

### DIFF
--- a/.github/workflows/npm-push.yml
+++ b/.github/workflows/npm-push.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Set up Node.js for deployment
         uses: actions/setup-node@v4
         with:
+          registry-url: 'https://registry.npmjs.org/'
           node-version: 18
 
       - run: npm publish


### PR DESCRIPTION
Pin push registry to npmjs.

As per the github actions [publish nodejs packages](https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry) page:

> Please note that you need to set the registry-url to https://registry.npmjs.org/ in setup-node to properly configure your credentials.